### PR TITLE
refs #4 マウントディレクトリをrails プロジェクトのディレクトリに変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:  # 具体的なcontainerはservices以下に記述する
     depends_on: # これが立ち上がってなければ起動しないという依存関係を設定する
       - mysql
     volumes: # マウント先、:を挟んで左がローカル上のdocker-composeがあるディレクトリ、右がcontainer内
-      - ./:/usr/local/src
+      - ./study_graphql/:/usr/local/src
     # commandは立ち上がった後にcontainerのメインプロセスを設定する。コメントアウト時はirbが起動する
     # command: "bash -c 'bundle && bin/rails db:migrate && bundle exec rails server'"
   mysql:


### PR DESCRIPTION
## 変更理由

https://github.com/akiumikin/study_graph_ql_in_d_group/pull/2

こいつで、rails newしたときにプロジェクト名を入れたため、ディレクトリを作成した
プロジェクト名を設定せずに`rails new . --api`とかなら一階層上に
railsの設定がきて色々ちょうどよかったけど、今回のも悪いわけじゃないから
後から変更（まぁいいかな程度で修正めんどい）

## 変更内容

rails containerのマウントディレクトリを合わせただけ