### PR TITLE
refs #5 railsでmysqlを使用できるようにする

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7' # docker-composeのver
 services:  # 具体的なcontainerはservices以下に記述する
   rails: # rails用のcontainer、mysqlとは順不同
     build: .
-    image: rails:1.0 # imageのver、管理用として名前をつければ良いverが変わるとDockerfileからbuildを始める
+    image: rails:1.1 # imageのver、管理用として名前をつければ良いverが変わるとDockerfileからbuildを始める
     container_name: rails # containerの名前、dockerコマンドでよく指定するので、用途がわかりやすいものを付ける
     tty: true
     stdin_open: true
@@ -22,7 +22,7 @@ services:  # 具体的なcontainerはservices以下に記述する
     environment:
       TZ: Asia/Tokyo
       MYSQL_ROOT_PASSWORD: P@ssw0rd
-      MYSQL_DATABASE: app
+      MYSQL_DATABASE: study_graph_ql_in_d_group_dev
       MYSQL_USER: app
       MYSQL_PASSWORD: app
     ports:

--- a/study_graphql/Gemfile
+++ b/study_graphql/Gemfile
@@ -5,8 +5,8 @@ ruby '2.6.3'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+
+gem 'mysql2'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/study_graphql/Gemfile.lock
+++ b/study_graphql/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.2.10)
+    mysql2 (0.5.2)
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
@@ -120,7 +121,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -137,11 +137,11 @@ DEPENDENCIES
   byebug
   graphql (= 1.9.6)
   listen (>= 3.0.5, < 3.2)
+  mysql2
   puma (~> 3.11)
   rails (~> 5.2.3)
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   tzinfo-data
 
 RUBY VERSION

--- a/study_graphql/config/database.yml
+++ b/study_graphql/config/database.yml
@@ -5,21 +5,24 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
+  adapter: mysql2
+  encoding: utf8
+  pool: 10
+  username: root
+  password: P@ssw0rd
+  host: mysql
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: study_graph_ql_in_d_group_dev
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: study_graph_ql_in_d_group_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: study_graph_ql_in_d_group_production # 今回使わない


### PR DESCRIPTION
## railsでみんな大好きmysqlを使用できるようにする

railsの標準だとsqlite3に接続するようになっている。  
それをmysqlに変更

### gemの設定

Gemfileに`gem 'mysql2'`を設定

### database.ymlを設定

詳細はファイルを参照のこと
本来ならuserとpasswordをroot用ではなく'app'の指定で
このdocker-compose.ymlなら使えてたはず...

まぁ勉強用でそこがキモじゃないからいいやの気持ちでrootを使用