### PR TITLE
refs #6 テーブル追加とrailsのモデルでアソシエーションの設定

### DIFF
--- a/study_graphql/app/models/blog.rb
+++ b/study_graphql/app/models/blog.rb
@@ -1,0 +1,3 @@
+class Blog < ApplicationRecord
+  belongs_to :user
+end

--- a/study_graphql/app/models/tag.rb
+++ b/study_graphql/app/models/tag.rb
@@ -1,0 +1,4 @@
+class Tag < ApplicationRecord
+  has_many :user_tag_relations
+  has_many :users, through: :user_tag_relations
+end

--- a/study_graphql/app/models/user.rb
+++ b/study_graphql/app/models/user.rb
@@ -1,0 +1,5 @@
+class User < ApplicationRecord
+  has_many :blogs, dependent: :destroy
+  has_many :user_tag_relations
+  has_many :tags, through: :user_tag_relations
+end

--- a/study_graphql/app/models/user_tag_relation.rb
+++ b/study_graphql/app/models/user_tag_relation.rb
@@ -1,0 +1,4 @@
+class UserTagRelation < ApplicationRecord
+  belongs_to :user
+  belongs_to :tag
+end

--- a/study_graphql/db/migrate/20190617135152_create_users.rb
+++ b/study_graphql/db/migrate/20190617135152_create_users.rb
@@ -1,0 +1,9 @@
+class CreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/study_graphql/db/migrate/20190617222455_create_blogs.rb
+++ b/study_graphql/db/migrate/20190617222455_create_blogs.rb
@@ -1,0 +1,11 @@
+class CreateBlogs < ActiveRecord::Migration[5.2]
+  def change
+    create_table :blogs do |t|
+      t.references :user, null: false, index: true, foreign_key: true
+      t.string :name, null: false
+      t.text :text, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/study_graphql/db/migrate/20190617223851_create_tags.rb
+++ b/study_graphql/db/migrate/20190617223851_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[5.2]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/study_graphql/db/migrate/20190617225630_create_user_tag_relations.rb
+++ b/study_graphql/db/migrate/20190617225630_create_user_tag_relations.rb
@@ -1,0 +1,10 @@
+class CreateUserTagRelations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :user_tag_relations do |t|
+      t.references :user, foreign_key: true
+      t.references :tag, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/study_graphql/db/schema.rb
+++ b/study_graphql/db/schema.rb
@@ -1,0 +1,49 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2019_06_17_225630) do
+
+  create_table "blogs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name", null: false
+    t.text "text", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_blogs_on_user_id"
+  end
+
+  create_table "tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "user_tag_relations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "tag_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tag_id"], name: "index_user_tag_relations_on_tag_id"
+    t.index ["user_id"], name: "index_user_tag_relations_on_user_id"
+  end
+
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_users_on_name", unique: true
+  end
+
+  add_foreign_key "blogs", "users"
+  add_foreign_key "user_tag_relations", "tags"
+  add_foreign_key "user_tag_relations", "users"
+end

--- a/study_graphql/test/fixtures/blogs.yml
+++ b/study_graphql/test/fixtures/blogs.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  text: MyText
+
+two:
+  name: MyString
+  text: MyText

--- a/study_graphql/test/fixtures/tags.yml
+++ b/study_graphql/test/fixtures/tags.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/study_graphql/test/fixtures/user_tag_relations.yml
+++ b/study_graphql/test/fixtures/user_tag_relations.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  tag: one
+
+two:
+  user: two
+  tag: two

--- a/study_graphql/test/fixtures/users.yml
+++ b/study_graphql/test/fixtures/users.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/study_graphql/test/models/blog_test.rb
+++ b/study_graphql/test/models/blog_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class BlogTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/study_graphql/test/models/tag_test.rb
+++ b/study_graphql/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/study_graphql/test/models/user_tag_relation_test.rb
+++ b/study_graphql/test/models/user_tag_relation_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UserTagRelationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/study_graphql/test/models/user_test.rb
+++ b/study_graphql/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## テーブル構成

だいたいこんな感じのテーブルを作成
（Blogでuser_idを加えたり、textの型をtextにしているけど）

![スクリーンショット 2019-06-17 22 41 03](https://user-images.githubusercontent.com/50658900/59642767-5bf42580-91a1-11e9-94a9-076924fa565a.png)

## テーブル作成

この辺をみて、generateコマンドを叩く

### railsでのテーブル作成コマンド
https://qiita.com/zaru/items/cde2c46b6126867a1a64

### リレーション貼るとき
https://qiita.com/Kohei_Kishimoto0214/items/cb9a3d3da57708fb52c9

generateコマンドで作成されたmigrateファイルに不足があれば手動で追加でも可

## リレーションの設定

それぞれのmodelにbelongs_toとかhas_many, throughとか設定した