### PR TITLE
refs #7 dockerで立ち上げたrailsにアクセスできるようにする

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7' # docker-composeのver
 services:  # 具体的なcontainerはservices以下に記述する
   rails: # rails用のcontainer、mysqlとは順不同
     build: .
-    image: rails:1.1 # imageのver、管理用として名前をつければ良いverが変わるとDockerfileからbuildを始める
+    image: rails:1.5 # imageのver、管理用として名前をつければ良いverが変わるとDockerfileからbuildを始める
     container_name: rails # containerの名前、dockerコマンドでよく指定するので、用途がわかりやすいものを付ける
     tty: true
     stdin_open: true
@@ -15,7 +15,7 @@ services:  # 具体的なcontainerはservices以下に記述する
     volumes: # マウント先、:を挟んで左がローカル上のdocker-composeがあるディレクトリ、右がcontainer内
       - ./study_graphql/:/usr/local/src
     # commandは立ち上がった後にcontainerのメインプロセスを設定する。コメントアウト時はirbが起動する
-    # command: "bash -c 'bundle && bin/rails db:migrate && bundle exec rails server'"
+    command: "bash -c 'bundle && bin/rails db:migrate && bundle exec rails server -b 0.0.0.0'"
   mysql:
     image: mysql:5.7
     container_name: mysql


### PR DESCRIPTION
## docker-compose.ymlの修正内容

command部分を記入しないとデフォルトのままのirbが立ち上がる  
railsサーバーを立ち上げるコマンドを記入しておく  
  
-b 0.0.0.0 のオプションでIPをバインドしないと  
docker外のブラウザから繋がらなかったので追加した