### PR TITLE
refs #9 単体のレコードをgraph-qlのqueryで取得してみる

### DIFF
--- a/study_graphql/app/graphql/types/query_type.rb
+++ b/study_graphql/app/graphql/types/query_type.rb
@@ -1,13 +1,11 @@
 module Types
   class QueryType < Types::BaseObject
-    # Add root-level fields here.
-    # They will be entry points for queries on your schema.
+    field :user, Types::UserType, null: false, description: 'ユーザー' do
+      argument :id, ID, required: true
+    end
 
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World!"
+    def user(id:)
+      User.find_by(id: id)
     end
   end
 end

--- a/study_graphql/app/graphql/types/user_type.rb
+++ b/study_graphql/app/graphql/types/user_type.rb
@@ -1,0 +1,7 @@
+class Types::UserType < Types::BaseObject
+  field :id,         ID,     null: false, description: 'ユーザーID'
+  field :name,       String, null: false, description: 'ユーザー名'
+  field :created_at, String, null: true,  description: 'ユーザーの作成日時'
+  field :updated_at, String, null: true,  description: 'ユーザーの更新日時'
+end
+  


### PR DESCRIPTION
## query_type.rb

### テスト設定の削除
今回削除している部分が、デフォルトで入っているテスト設定  
フロントから下記のようなqueryを投げると`Hello World!`と返してくる  
この辺りのサイトが解説してる  
https://qiita.com/yuta-ushijima/items/6f800f20c83e79e6de64

```
query get_user{
  test_field
}
```

今回は特に不要なので削除

## userテーブルのレコードを引いてこれるようにする
`query_type.rb`ではuserのfieldとそれを返すためのメソッドを追加  
ただし、このuserではuserテーブルの情報が返したいので複数のfieldを内包させたい  
そのため、自分でUserTypeというtypeを作成する  
  
user_type.rbでは、UserTypeのclassの中でfieldを定義する  
こんな感じで定義しておくと下記のようなqueryとレスポンスになる  
（左がquery、右がレスポンス）
![スクリーンショット 2019-06-19 23 49 18](https://user-images.githubusercontent.com/50658900/59776754-4c362780-92ee-11e9-86f6-974b04eff4ec.png)

queryでは、updated_atやcreated_atは必要ない想定で省略しているが、  
IDやnameと合わせて列挙すればレスポンスを得られる

このときにはRailsサーバー側からMySQLへのログは下記のようになる  
```
User Load (0.5ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` = 1 LIMIT 1
  ↳ app/graphql/types/query_type.rb:8
```

1件の取得なら問題はないが、1対多のレコードの情報も合わせて取得させようとした場合などに  
n+1問題が発生する。n+1問題が発生する実装と、それを解消するためのgraphql-batchは別プルリクとする