### PR TITLE
refs #10 1対多のリレーションデータを合わせて取得できるようにする（user ⇨ blogs）

### DIFF
--- a/study_graphql/app/graphql/types/blog_type.rb
+++ b/study_graphql/app/graphql/types/blog_type.rb
@@ -1,0 +1,8 @@
+class Types::BlogType < Types::BaseObject
+  field :id,         ID,     null: false, description: 'ブログID'
+  field :name,       String, null: false, description: 'ブログ名称'
+  field :text,       String, null: false, description: 'ブログのテキスト内容'
+  field :created_at, String, null: true,  description: 'ブログの作成日時'
+  field :updated_at, String, null: true,  description: 'ブログの更新日時'
+end
+  

--- a/study_graphql/app/graphql/types/user_type.rb
+++ b/study_graphql/app/graphql/types/user_type.rb
@@ -1,7 +1,9 @@
 class Types::UserType < Types::BaseObject
-  field :id,         ID,     null: false, description: 'ユーザーID'
-  field :name,       String, null: false, description: 'ユーザー名'
-  field :created_at, String, null: true,  description: 'ユーザーの作成日時'
-  field :updated_at, String, null: true,  description: 'ユーザーの更新日時'
+  field :id,         ID,                null: false, description: 'ユーザーID'
+  field :name,       String,            null: false, description: 'ユーザー名'
+  field :created_at, String,            null: true,  description: 'ユーザーの作成日時'
+  field :updated_at, String,            null: true,  description: 'ユーザーの更新日時'
+
+  field :blogs,      [Types::BlogType], null: true,  description: 'ユーザーに紐づくブログ'
 end
   


### PR DESCRIPTION
## BlogTypeを追加

Userに対して1対多でBlogテーブルが作成されているので  
Blogに対するTypeを設定する  
  
内容は https://github.com/akiumikin/study_graph_ql_in_d_group/pull/11 のUserTypeにtextのcolumnを追加した形です。

## UserTypeのfieldにBlogsを追加

UserTypesのfieldにBlogsを追加する  
そのfieldにはBlogTypeを指定する

## queryなど

graphiqlからのクエリと表示されるレスポンス

![スクリーンショット 2019-06-20 20 25 17](https://user-images.githubusercontent.com/50658900/59847805-83fca800-939e-11e9-976a-b14e8869ebe5.png)

userの中でblogsを指定して、欲しいblogsのfieldも指定すれば合わせたレスポンスが取得できる


サーバーからDBへのクエリ

```
  User Load (1.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` = 1 LIMIT 1
  ↳ app/graphql/types/query_type.rb:8
  Blog Load (0.6ms)  SELECT `blogs`.* FROM `blogs` WHERE `blogs`.`user_id` = 1
  ↳ app/controllers/graphql_controller.rb:10
```