### PR TITLE
refs #11 多対多のテーブルをuser_types.rbのfieldに設定する

### DIFF
--- a/study_graphql/app/graphql/types/tag_type.rb
+++ b/study_graphql/app/graphql/types/tag_type.rb
@@ -1,0 +1,7 @@
+class Types::TagType < Types::BaseObject
+  field :id,         ID,                null: false, description: 'タグID'
+  field :name,       String,            null: false, description: 'タグ名'
+  field :created_at, String,            null: true,  description: 'タグの作成日時'
+  field :updated_at, String,            null: true,  description: 'タグの更新日時'
+end
+  

--- a/study_graphql/app/graphql/types/user_type.rb
+++ b/study_graphql/app/graphql/types/user_type.rb
@@ -5,5 +5,17 @@ class Types::UserType < Types::BaseObject
   field :updated_at, String,            null: true,  description: 'ユーザーの更新日時'
 
   field :blogs,      [Types::BlogType], null: true,  description: 'ユーザーに紐づくブログ'
+  field :tag,        Types::TagType,    null: true,  description: 'ユーザーに紐づくタグ' do
+    argument :id  , ID , required: true
+  end
+  field :tags,       [Types::TagType],  null: true,  description: 'ユーザーに紐づくタグ全部'
+
+  def tag(id:)
+    object.tags.find(id)
+  end
+
+  def tags
+    object.tags
+  end
 end
   


### PR DESCRIPTION
## tag_type.rbを作成

こちらのuser_type.rbと同じようにtag_type.rbを作成  
https://github.com/akiumikin/study_graph_ql_in_d_group/pull/10  

## user_type.rbにtagのfieldを追加

### 指定のタグを取得

"tag" fieldに上記で作成したTagTypeを指定して作成  
このままだと、中間テーブルを挟んで解決できないので  
同名のメソッドを作成して、解決できるようにした。  

```
  def tag(id:)
    object.tags.find(id)
  end
```

この場合のgraphiqlの例

![スクリーンショット 2019-06-20 21 18 00](https://user-images.githubusercontent.com/50658900/59849346-587bbc80-93a2-11e9-8656-aac8c05838a7.png)

発行されるDBへのクエリ

```
  User Load (1.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` = 1 LIMIT 1
  ↳ app/graphql/types/query_type.rb:8
  Tag Load (2.2ms)  SELECT  `tags`.* FROM `tags` INNER JOIN `user_tag_relations` ON `tags`.`id` = `user_tag_relations`.`tag_id` WHERE `user_tag_relations`.`user_id` = 1 AND `tags`.`id` = 1 LIMIT 1
```

### 紐づくタグを全て取得

"tags"のfieldをuserに追加、こちらはメソッドの中身が下記の形式であることと、  
userに設定したtagsのtypeが[]で囲われていることに注意（複数の場合は囲う）

```
  def tag(id:)
    object.tags
  end
```

この場合のgraphiqlの例

![スクリーンショット 2019-06-20 21 18 24](https://user-images.githubusercontent.com/50658900/59850252-c0cb9d80-93a4-11e9-9912-81a76dc00533.png)

発行されるDBへのクエリ

```
  User Load (0.8ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` = 1 LIMIT 1
  ↳ app/graphql/types/query_type.rb:8
  Tag Load (0.9ms)  SELECT `tags`.* FROM `tags` INNER JOIN `user_tag_relations` ON `tags`.`id` = `user_tag_relations`.`tag_id` WHERE `user_tag_relations`.`user_id` = 1
```