### PR TITLE
refs #12 userを複数同時に取得できるようにする（graph-qlのn+1問題）

### DIFF
--- a/study_graphql/app/graphql/types/query_type.rb
+++ b/study_graphql/app/graphql/types/query_type.rb
@@ -3,9 +3,16 @@ module Types
     field :user, Types::UserType, null: false, description: 'ユーザー' do
       argument :id, ID, required: true
     end
+    field :users, [Types::UserType], null: false, description: 'ユーザー' do
+      argument :ids, [ID], required: true
+    end
 
     def user(id:)
       User.find_by(id: id)
+    end
+
+    def users(ids:)
+      User.where(id: ids).limit(100)
     end
   end
 end


### PR DESCRIPTION
## userを複数人同時に取得できるように

query_type.rbに複数のusersのfieldを追加して、  
複数人の情報を同時に取れるようにした  

## n+1問題

usersを取得する際に1対多で繋がっているtagsを合わせて取得する  
その際のgraphiqlは下記の感じ

![スクリーンショット 2019-06-21 9 04 35](https://user-images.githubusercontent.com/50658900/59888630-9bba4780-9403-11e9-902a-96b4581ac3c3.png)

発行されるクエリが問題で下記となる

```
  User Load (1.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` IN (1, 2, 3) LIMIT 100
  ↳ app/controllers/graphql_controller.rb:10
  Tag Load (0.9ms)  SELECT `tags`.* FROM `tags` INNER JOIN `user_tag_relations` ON `tags`.`id` = `user_tag_relations`.`tag_id` WHERE `user_tag_relations`.`user_id` = 1
  ↳ app/controllers/graphql_controller.rb:10
  Tag Load (0.8ms)  SELECT `tags`.* FROM `tags` INNER JOIN `user_tag_relations` ON `tags`.`id` = `user_tag_relations`.`tag_id` WHERE `user_tag_relations`.`user_id` = 2
  ↳ app/controllers/graphql_controller.rb:10
```

user自体は`ID (1, 2, 3)`とまとまっているが、tagsは1ユーザーごとで別々のクエリになってしまっている  
これをまとめるためにgraph-ql batchを次には入れていく