### PR TITLE
refs #14 userテーブルからのリレーションテーブルへの参照にgraph ql batchを使うようにする

### DIFF
--- a/study_graphql/Gemfile
+++ b/study_graphql/Gemfile
@@ -51,3 +51,7 @@ gem 'graphql', '1.9.6'
 # https://github.com/rmosolgo/graphiql-rails
 # 2019/6/16時点の最新を設定
 gem 'graphiql-rails', '1.7.0'
+
+# https://github.com/Shopify/graphql-batch
+# 2019/6/16時点の最新を設定
+gem 'graphql-batch', '0.4.0'

--- a/study_graphql/Gemfile.lock
+++ b/study_graphql/Gemfile.lock
@@ -57,6 +57,9 @@ GEM
       railties
       sprockets-rails
     graphql (1.9.6)
+    graphql-batch (0.4.0)
+      graphql (>= 1.3, < 2)
+      promise.rb (~> 0.7.2)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     listen (3.1.5)
@@ -80,6 +83,7 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
+    promise.rb (0.7.4)
     puma (3.12.1)
     rack (2.0.7)
     rack-test (1.1.0)
@@ -140,6 +144,7 @@ DEPENDENCIES
   byebug
   graphiql-rails (= 1.7.0)
   graphql (= 1.9.6)
+  graphql-batch (= 0.4.0)
   listen (>= 3.0.5, < 3.2)
   mysql2
   puma (~> 3.11)

--- a/study_graphql/app/graphql/association_loader.rb
+++ b/study_graphql/app/graphql/association_loader.rb
@@ -1,0 +1,48 @@
+class AssociationLoader < GraphQL::Batch::Loader
+  def self.validate(model, association_name)
+    new(model, association_name)
+    nil
+  end
+  
+  def initialize(model, association_name)
+    @model = model
+    @association_name = association_name
+    validate
+  end
+  
+  def load(record)
+    raise TypeError, "#{@model} loader can't load association for #{record.class}" unless record.is_a?(@model)
+    return Promise.resolve(read_association(record)) if association_loaded?(record)
+    super
+  end
+  
+  # We want to load the associations on all records, even if they have the same id
+  def cache_key(record)
+    record.object_id
+  end
+  
+  def perform(records)
+    preload_association(records)
+    records.each { |record| fulfill(record, read_association(record)) }
+  end
+  
+  private
+  
+  def validate
+    unless @model.reflect_on_association(@association_name)
+      raise ArgumentError, "No association #{@association_name} on #{@model}"
+    end
+  end
+  
+  def preload_association(records)
+    ::ActiveRecord::Associations::Preloader.new.preload(records, @association_name)
+  end
+  
+  def read_association(record)
+    record.public_send(@association_name)
+  end
+  
+  def association_loaded?(record)
+    record.association(@association_name).loaded?
+  end
+end

--- a/study_graphql/app/graphql/record_loader.rb
+++ b/study_graphql/app/graphql/record_loader.rb
@@ -1,0 +1,25 @@
+class RecordLoader < GraphQL::Batch::Loader
+  def initialize(model, column: model.primary_key, where: nil)
+    @model = model
+    @column = column.to_s
+    @column_type = model.type_for_attribute(@column)
+    @where = where
+  end
+
+  def load(key)
+    super(@column_type.cast(key))
+  end
+
+  def perform(keys)
+    query(keys).each { |record| fulfill(record.public_send(@column), record) }
+    keys.each { |key| fulfill(key, nil) unless fulfilled?(key) }
+  end
+
+  private
+
+  def query(keys)
+    scope = @model
+    scope = scope.where(@where) if @where
+    scope.where(@column => keys)
+  end
+end

--- a/study_graphql/app/graphql/study_graphql_schema.rb
+++ b/study_graphql/app/graphql/study_graphql_schema.rb
@@ -1,4 +1,6 @@
 class StudyGraphqlSchema < GraphQL::Schema
   mutation(Types::MutationType)
   query(Types::QueryType)
+
+  use(GraphQL::Batch)
 end

--- a/study_graphql/app/graphql/types/user_type.rb
+++ b/study_graphql/app/graphql/types/user_type.rb
@@ -10,12 +10,18 @@ class Types::UserType < Types::BaseObject
   end
   field :tags,       [Types::TagType],  null: true,  description: 'ユーザーに紐づくタグ全部'
 
+  def blogs
+    AssociationLoader.for(User, :blogs).load(object)
+  end
+
   def tag(id:)
-    object.tags.find(id)
+    AssociationLoader.for(User, :tags).load(object).then do |tags|
+      tags.detect { |tag| tag.id == id.to_i }
+    end
   end
 
   def tags
-    object.tags
+    AssociationLoader.for(User, :tags).load(object)
   end
 end
   


### PR DESCRIPTION
## graph ql batchの導入

### gemへの設定
Gemfileに`gem 'graphiql-rails'`を追加して、`bundle install`する  

### loaderの設定
公式サイトのサンプル  
https://github.com/Shopify/graphql-batch/tree/058213b78775c791135bf7db784b7d10007d5ade/examples  
を参考にgraphqlディレクトリ以下にloaderを作成する

## typeの中でloaderを使用する

### 使い方
コード参照

### 変更によるDBへのクエリの変化

【blogs変更前】
```
  User Load (0.5ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` IN (1, 2, 3) LIMIT 100
  ↳ app/controllers/graphql_controller.rb:10
  Blog Load (0.5ms)  SELECT `blogs`.* FROM `blogs` WHERE `blogs`.`user_id` = 1
  ↳ app/controllers/graphql_controller.rb:10
  Blog Load (1.3ms)  SELECT `blogs`.* FROM `blogs` WHERE `blogs`.`user_id` = 2
  ↳ app/controllers/graphql_controller.rb:10

blogsがuserごとにクエリ発行される
```

【blogs変更後】
```
  User Load (0.6ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` IN (1, 2, 3) LIMIT 100
  ↳ app/controllers/graphql_controller.rb:10
  Blog Load (0.4ms)  SELECT `blogs`.* FROM `blogs` WHERE `blogs`.`user_id` IN (1, 2)
  ↳ app/graphql/association_loader.rb:38

blogsの部分がuser_idをまとめた形でクエリが発行される
```

【tags変更前】
```
  User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` IN (1, 2, 3) LIMIT 100
  ↳ app/controllers/graphql_controller.rb:10
  Tag Load (0.8ms)  SELECT `tags`.* FROM `tags` INNER JOIN `user_tag_relations` ON `tags`.`id` = `user_tag_relations`.`tag_id` WHERE `user_tag_relations`.`user_id` = 1
  ↳ app/controllers/graphql_controller.rb:10
  Tag Load (0.9ms)  SELECT `tags`.* FROM `tags` INNER JOIN `user_tag_relations` ON `tags`.`id` = `user_tag_relations`.`tag_id` WHERE `user_tag_relations`.`user_id` = 2
  ↳ app/controllers/graphql_controller.rb:10

こちらもuserごとにクエリ発行される
```

【tags変更後】
```
  User Load (0.6ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` IN (1, 2, 3) LIMIT 100
  ↳ app/controllers/graphql_controller.rb:10
  UserTagRelation Load (0.4ms)  SELECT `user_tag_relations`.* FROM `user_tag_relations` WHERE `user_tag_relations`.`user_id` IN (1, 2)
  ↳ app/graphql/association_loader.rb:38
  Tag Load (0.4ms)  SELECT `tags`.* FROM `tags` WHERE `tags`.`id` IN (1, 2, 3)
  ↳ app/graphql/association_loader.rb:38

同上
```