### PR TITLE
refs #16 userテーブルに対してmutationで作成・更新・削除を行う

### DIFF
--- a/study_graphql/app/graphql/mutations/base_mutation.rb
+++ b/study_graphql/app/graphql/mutations/base_mutation.rb
@@ -1,0 +1,2 @@
+class Mutations::BaseMutation < GraphQL::Schema::RelayClassicMutation
+end

--- a/study_graphql/app/graphql/mutations/delete_user.rb
+++ b/study_graphql/app/graphql/mutations/delete_user.rb
@@ -1,0 +1,18 @@
+class Mutations::DeleteUser < Mutations::BaseMutation
+  description 'ユーザーの削除を行う'
+  
+  # 作成用メソッドの引数
+  argument :id, ID, required: true, description: 'ユーザーID'
+  
+  # responseのfield
+  field :user,          Types::UserType, null: true, description: 'ユーザー変更内容の戻り値'
+  field :error_message, String,          null: true, description: 'エラー発生時のサーバからのメッセージ'
+  
+  def resolve(id: nil)
+    res_user = User.find(id).delete
+    
+    { user: res_user, error_message: nil }
+  rescue => e
+    { user: res_user, error_message: e.message }
+  end
+end

--- a/study_graphql/app/graphql/mutations/upsert_user.rb
+++ b/study_graphql/app/graphql/mutations/upsert_user.rb
@@ -1,0 +1,25 @@
+class Mutations::UpsertUser < Mutations::BaseMutation
+  description 'ユーザーの作成・更新を行う'
+  
+  # 作成用メソッドの引数
+  argument :id,   ID,     required: false, description: 'ユーザーID、有：更新、無：作成'
+  argument :name, String, required: true,  description: 'ユーザー名'
+  
+  # responseのfield
+  field :user,          Types::UserType, null: true, description: 'ユーザー変更内容の戻り値'
+  field :error_message, String,          null: true, description: 'エラー発生時のサーバからのメッセージ'
+  
+  def resolve(id: nil, name:)
+    res_user = nil
+
+    if id.present? # 更新処理
+      res_user = User.find(id).update!(name: name)
+    else           # 作成処理
+      res_user = User.create!(name: name)
+    end
+    
+    { user: res_user, error_message: nil }
+  rescue => e
+    { user: res_user, error_message: e.message }
+  end
+end

--- a/study_graphql/app/graphql/types/mutation_type.rb
+++ b/study_graphql/app/graphql/types/mutation_type.rb
@@ -1,10 +1,6 @@
 module Types
   class MutationType < Types::BaseObject
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World"
-    end
+    field :upsert_user, mutation: Mutations::UpsertUser, null: false
+    field :delete_user, mutation: Mutations::DeleteUser, null: false
   end
 end


### PR DESCRIPTION
## mutationを使用する下準備

サンプル規模のコードでは問題ないが、mutationのbaseクラスを作成しておくと  
mutation全体で使用する共通処理などが楽になるらしいので作成しておく

## mutationの設定

主に下記の２点の設定を行う  
1. mutationの作成
1. mutation_typeに上記の作成したmutationを設定

## mutationをgraphiqlから実行する際の例

![スクリーンショット 2019-06-22 14 51 55](https://user-images.githubusercontent.com/50658900/59960097-c8528a00-94fd-11e9-9fef-c5323ed4c2c5.png)
