### PR TITLE
refs #19 mutationのrspecを追加

### DIFF
--- a/study_graphql/spec/requests/graphql/mutations/delete_user_spec.rb
+++ b/study_graphql/spec/requests/graphql/mutations/delete_user_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe '【delete_user mutation】', type: :request do
+  let!(:user) { FactoryBot.create(:user) }
+
+  context 'Userの削除の場合' do
+    before do
+      mutation = <<-MUTATION
+        mutation {
+          deleteUser(input: {
+            id: "#{user.id}"
+          }) {
+            user {
+              id
+              name
+              createdAt
+              updatedAt
+            }
+            errorMessage  
+          }
+        }
+      MUTATION
+      @post = post(graphql_path, params: { query: mutation })
+      @json = JSON.parse(response.body, symbolize_names: true)
+    end
+
+    it '削除したUserのattributesが返ること' do
+      res_data = @json[:data][:deleteUser][:user]
+      expect_data = graphql_format(user)
+
+      expect(@post).to eq 200
+      expect(res_data).to eq expect_data
+    end
+  end
+
+  context '存在しないUserの削除の場合' do
+    before do
+      mutation = <<-MUTATION
+        mutation {
+          deleteUser(input: {
+            id: 999999
+          }) {
+            user {
+              id
+              name
+              createdAt
+              updatedAt
+            }
+            errorMessage  
+          }
+        }
+      MUTATION
+      @post = post(graphql_path, params: { query: mutation })
+      @json = JSON.parse(response.body, symbolize_names: true)
+    end
+
+    it '削除後のUserが返らずエラーメッセージが存在すること' do
+      res_data = @json[:data][:deleteUser][:user]
+      error_message = @json[:data][:deleteUser][:errorMessage]
+      expect_data = nil
+
+      expect(@post).to eq 200
+      expect(res_data).to eq expect_data
+      expect(error_message.present?).to eq true
+    end
+  end
+end

--- a/study_graphql/spec/requests/graphql/mutations/upsert_user_spec.rb
+++ b/study_graphql/spec/requests/graphql/mutations/upsert_user_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe '【upsert_user mutation】', type: :request do
+  let!(:user) { FactoryBot.create(:user) }
+
+  context 'Userの作成の場合' do
+    before do
+      @name = "#{FFaker::NameJA.name}_created"
+      mutation = <<-MUTATION
+        mutation {
+          upsertUser(input: {
+            name: "#{@name}"
+          }) {
+            user {
+              id
+              name
+              createdAt
+              updatedAt
+            }
+            errorMessage  
+          }
+        }
+      MUTATION
+      @post = post(graphql_path, params: { query: mutation })
+      @json = JSON.parse(response.body, symbolize_names: true)
+    end
+
+    it '作成後のUserのattributesが返ること' do
+      res_data = @json[:data][:upsertUser][:user]
+      error_message = @json[:data][:upsertUser][:errorMessage]
+      expect_data = graphql_format(User.find(res_data[:id]))
+
+      expect(@post).to eq 200
+      expect(res_data).to eq expect_data
+      expect(error_message).to eq nil
+      # 作成の場合IDで期待値とレスポンスの相対が取れないためnameで代用
+      expect(res_data[:name]).to eq @name
+    end
+  end
+
+  context '更新可能なUserの更新の場合' do
+    before do
+      mutation = <<-MUTATION
+        mutation {
+          upsertUser(input: {
+            id: "#{user.id}"
+            name: "#{FFaker::NameJA.name}_updated"
+          }) {
+            user {
+              id
+              name
+              createdAt
+              updatedAt
+            }
+            errorMessage  
+          }
+        }
+      MUTATION
+      @post = post(graphql_path, params: { query: mutation })
+      @json = JSON.parse(response.body, symbolize_names: true)
+    end
+
+    it '更新後のUserのattributesが返ること' do
+      res_data = @json[:data][:upsertUser][:user]
+      error_message = @json[:data][:upsertUser][:errorMessage]
+      expect_data = graphql_format(user.reload)
+
+      expect(@post).to eq 200
+      expect(res_data).to eq expect_data
+      expect(error_message).to eq nil
+    end
+  end
+
+  context '存在しないUserの更新の場合' do
+    before do
+      mutation = <<-MUTATION
+        mutation {
+          upsertUser(input: {
+            id: 999999
+            name: "#{FFaker::NameJA.name}_updated"
+          }) {
+            user {
+              id
+              name
+              createdAt
+              updatedAt
+            }
+            errorMessage  
+          }
+        }
+      MUTATION
+      @post = post(graphql_path, params: { query: mutation })
+      @json = JSON.parse(response.body, symbolize_names: true)
+    end
+
+    it '更新後のUserが返らずエラーメッセージが存在すること' do
+      res_data = @json[:data][:upsertUser][:user]
+      error_message = @json[:data][:upsertUser][:errorMessage]
+      expect_data = nil
+
+      expect(@post).to eq 200
+      expect(res_data).to eq expect_data
+      expect(error_message.present?).to eq true
+    end
+  end
+end


### PR DESCRIPTION
## upsertUser
基本的にはtype(query)のテストと同様です。  
差分的な部分だけ注釈します  

1. mutationであることを明記する
1. 作成時にはidでのリクエストとレスポンスの突き合わせができないため、相対が特殊
1. 作成/更新の期待結果では対象のユーザーをfindして正しいものか確認

```
【mutationであることを明記】
graphqlに投げるクエリの名称を"mutation"としたことと  
describeのテキストに"mutation"と入れています
```

```
【作成時のIDを使わないデータの相対】

IDが使えないため、正しいユーザーの情報が帰ってきているか型を  
確認しても不十分な点が発生します。  
なので、代用としてリクエストで送った"name"とレスポンスの"name"で  
データの相対を見ています。  

本来ならばunique制約のあるcolumnの情報が良いです
（まぁできる範囲でテストは書く）
```

```
【作成/更新時に期待結果をfindしている部分】
想定したUserの型が正しく帰ってきているかや、情報が書き換わっていることの確認です。  
ここでfindをし直さないと、factory_botで作成時の情報になるのでいまいちかなと...
```


## deleteUser
こちらはupsertUserとほぼ同様のため言うことが特にないです