### PR TITLE
refs #21 別リポジトリのフロントエンドからのリクエストを受け付けるようにする

### DIFF
--- a/study_graphql/Gemfile
+++ b/study_graphql/Gemfile
@@ -26,7 +26,7 @@ gem 'puma', '~> 3.11'
 gem 'bootsnap', '>= 1.1.0', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
+gem 'rack-cors'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/study_graphql/Gemfile.lock
+++ b/study_graphql/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
       pry (>= 0.10.4)
     puma (3.12.1)
     rack (2.0.7)
+    rack-cors (1.0.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.3)
@@ -190,6 +191,7 @@ DEPENDENCIES
   pry-doc
   pry-rails
   puma (~> 3.11)
+  rack-cors
   rails (~> 5.2.3)
   rspec-rails (~> 3.8)
   spring

--- a/study_graphql/config/initializers/cors.rb
+++ b/study_graphql/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins 'http://localhost:8080'
+
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end


### PR DESCRIPTION
## rack-cors

他のドメインのサイトからのリクエストを受け付けるためには  
rack-corsの設定が必要なようだったので追加した  

方法としてはデフォルトでgemfileにコメントアウトされている  
rack-corsを有効化してあげる程度なので、細かいことは  
公式サイトを確認すること https://github.com/cyu/rack-cors

## 受付先のフロントエンドの変更

こちらを参照
https://github.com/akiumikin/study_graph_ql_in_d_group_front/pull/6